### PR TITLE
Ability to add * to repo names

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -36,7 +36,7 @@ variable "repositories" {
     # organization/repository format used by GitHub.
     condition = length([
       for repo in var.repositories : 1
-      if length(regexall("^[A-Za-z0-9_.-]+?/([A-Za-z0-9_.:/-]+|\\*)$", repo)) > 0
+      if length(regexall("^[A-Za-z0-9_.-]+?/([A-Za-z0-9_*.:/-]+|\\*)$", repo)) > 0
     ]) == length(var.repositories)
     error_message = "Repositories must be specified in the organization/repository format."
   }


### PR DESCRIPTION
Allow `*` in repo names.

In cases where there are a lot of repositories that make up the AWS policy, we hit the "Role trust policy length". By default this limit is 2048 chars, expandable to 4096 as a hard limit. See https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html
